### PR TITLE
Wizard issues #71: Contact plugin Wizard

### DIFF
--- a/cc3d/twedit5/Plugins/CC3DMLGenerator/CC3DMLGeneratorBase.py
+++ b/cc3d/twedit5/Plugins/CC3DMLGenerator/CC3DMLGeneratorBase.py
@@ -860,6 +860,13 @@ class CC3DMLGeneratorBase:
     def generateFocalPointPlasticityPlugin(self, *args, **kwds):
 
         m_element = self.mElement
+        internal_contact_plugin_used = False
+        try:
+            if kwds['internal_contact_energies'] is not None:
+                if len(kwds['internal_contact_energies']) > 0:
+                    internal_contact_plugin_used = True
+        except LookupError:
+            internal_contact_plugin_used = False
 
         try:
             n_order = kwds['NeighborOrder']
@@ -886,29 +893,30 @@ class CC3DMLGeneratorBase:
         m_element.addComment("See CC3D manual for details on FPP plugin ")
 
         for type_name1, type_name2 in self.decorated_type_pairs:
+            if type_name1 != "Medium" and type_name2 != "Medium":
+                m_element.addComment("newline")
+                attr = {"Type1": type_name1, "Type2": type_name2}
 
-            m_element.addComment("newline")
-            attr = {"Type1": type_name1, "Type2": type_name2}
+                param_element = m_element.ElementCC3D("Parameters", attr)
+                param_element.ElementCC3D("Lambda", {}, 10)
+                param_element.ElementCC3D("ActivationEnergy", {}, -50)
+                param_element.ElementCC3D("TargetDistance", {}, 7)
+                param_element.ElementCC3D("MaxDistance", {}, 20)
+                param_element.ElementCC3D("MaxNumberOfJunctions", {"NeighborOrder": 1}, 1)
 
-            param_element = m_element.ElementCC3D("Parameters", attr)
-            param_element.ElementCC3D("Lambda", {}, 10)
-            param_element.ElementCC3D("ActivationEnergy", {}, -50)
-            param_element.ElementCC3D("TargetDistance", {}, 7)
-            param_element.ElementCC3D("MaxDistance", {}, 20)
-            param_element.ElementCC3D("MaxNumberOfJunctions", {"NeighborOrder": 1}, 1)
+        if internal_contact_plugin_used:
+            for type_name1, type_name2 in self.decorated_type_pairs:
+                if type_name1 != "Medium" and type_name2 != "Medium":
+                    m_element.addComment("newline")
 
-        for type_name1, type_name2 in self.decorated_type_pairs:
+                    attr = {"Type1": type_name1, "Type2": type_name2}
 
-            m_element.addComment("newline")
-
-            attr = {"Type1": type_name1, "Type2": type_name2}
-
-            param_element = m_element.ElementCC3D("InternalParameters", attr)
-            param_element.ElementCC3D("Lambda", {}, 10)
-            param_element.ElementCC3D("ActivationEnergy", {}, -50)
-            param_element.ElementCC3D("TargetDistance", {}, 7)
-            param_element.ElementCC3D("MaxDistance", {}, 20)
-            param_element.ElementCC3D("MaxNumberOfJunctions", {"NeighborOrder": 1}, 1)
+                    param_element = m_element.ElementCC3D("InternalParameters", attr)
+                    param_element.ElementCC3D("Lambda", {}, 10)
+                    param_element.ElementCC3D("ActivationEnergy", {}, -50)
+                    param_element.ElementCC3D("TargetDistance", {}, 7)
+                    param_element.ElementCC3D("MaxDistance", {}, 20)
+                    param_element.ElementCC3D("MaxNumberOfJunctions", {"NeighborOrder": 1}, 1)
 
         m_element.addComment("newline")
 

--- a/cc3d/twedit5/Plugins/CC3DProject/ContactPluginWidget.py
+++ b/cc3d/twedit5/Plugins/CC3DProject/ContactPluginWidget.py
@@ -56,6 +56,8 @@ class ContactPluginWidget(QWidget):
         self.contact_cell_cell_energy: list[tuple[str, str, str]] = []  # list[ tuple[ mol1, mol2, binding param]]
         self.internal_contact_cell_cell_energy: list[tuple[str, str, str]] = []  # list[ tuple[ mol1, mol2, binding param]]
         self.contact_internal_callBack = contact_internal_call_back
+        self.focal_plasticity_plugin_used = False
+
         descr_font = QFont()
         descr_font.setPointSize(CONTACT_DESCR_FONT_SIZE)
         self.ui.contact_reset_tablesPB.setText(RESET_MATRIX_TABLES_PB_TEXT)
@@ -161,9 +163,9 @@ class ContactPluginWidget(QWidget):
                     cell_type_v = self.ui.contact_matrix_table.verticalHeaderItem(row).text()
                     cell_to_update: QTableWidgetItem = self.ui.contact_matrix_table.item(row, column)
                     if cell_to_update:
-                        if cell_type_h == MEDIUM_CELL_TYPE and cell_type_v == MEDIUM_CELL_TYPE:
-                            # Check if both 'MEDIUM_CELL_TYPE' type, if so then default energy is '-',
-                            # Contact between Medium cell types is nonsensical.
+                        if (cell_type_h == MEDIUM_CELL_TYPE or cell_type_v == MEDIUM_CELL_TYPE) and self.focal_plasticity_plugin_used:
+                            # Check if both 'MEDIUM_CELL_TYPE' type, if so then default energy is '-'
+                            # when FocalPoint Plasticity Plugin is used.
                             cell_to_update.setText("-")
                         else:
                             cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))
@@ -256,7 +258,8 @@ class ContactPluginWidget(QWidget):
         return issues
 
     def initContactMatrix(self, cell_types: list[str]):
-        """ Sets up the initial Contact matrix then fills with default values."""
+        """ Sets up the initial Contact matrix then fills with default values. If FocalPoint Plasticity
+            Plugin is used then all Medium entries are '-'. """
 
         header_font = QFont()
         header_font.setPointSize(CONTACT_TABLE_HEADER_FONT_SIZE)
@@ -278,14 +281,14 @@ class ContactPluginWidget(QWidget):
 
         for row in range(0, cell_type_count):
             self.ui.contact_matrix_table.insertRow(row)
+            cell_type_h = self.ui.contact_matrix_table.horizontalHeaderItem(row).text()
             for column in range(0, cell_type_count):
-                cell_type_h = self.ui.contact_matrix_table.horizontalHeaderItem(column).text()
                 if cell_type_h == MEDIUM_CELL_TYPE:
-                    medium_col = column
+                    medium_col = row
                 if row <= column:
-                    if cell_type_h == MEDIUM_CELL_TYPE and row == medium_col:
-                        # Check if 'MEDIUM_CELL_TYPE' type, if so then default energy is '-',
-                        # Adhesion energy between Medium cell types is nonsensical.
+                    if (cell_type_h == MEDIUM_CELL_TYPE or medium_col == column) and \
+                            self.focal_plasticity_plugin_used:
+                        # Check if 'MEDIUM_CELL_TYPE' type and FPP used, if so then default energy is '-'.
                         binding_par_item = QTableWidgetItem("-")
                     else:
                         binding_par_item = QTableWidgetItem(str(DEFAULT_CONTACT_ENERGY))
@@ -312,7 +315,7 @@ class ContactPluginWidget(QWidget):
         self.ui.contact_matrix_table.blockSignals(False)
 
     def initInternalContactMatrix(self, cell_types: list[str]):
-        """ Sets up the initial Internal Contact matrix with default values."""
+        """ Sets up the initial Internal Contact matrix with default values. """
 
         self.ui.contact_internalCB.setChecked(True)
         self.ui.internal_contact_matrixGB.setEnabled(True)
@@ -370,7 +373,8 @@ class ContactPluginWidget(QWidget):
 
     def setUpSortedCellsContactEnergiesMatrix(self):
         """ Generates default contact energies for contact matrix that should lead to cell type sorting.
-            Updates the contact_matrix_table (QTableWidget) with new energy values."""
+            Updates the contact_matrix_table (QTableWidget) with new energy values. If FocalPoint Plasticity
+            Plugin is used then all 'Medium' entries are '-'. """
 
         table_cell_font = QFont()
         table_cell_font.setPointSize(CONTACT_TABLE_HEADER_FONT_SIZE)
@@ -383,11 +387,15 @@ class ContactPluginWidget(QWidget):
                         cell_2: str = self.ui.contact_matrix_table.verticalHeaderItem(column).text()
                         if row < column:
                             if cell_1 == MEDIUM_CELL_TYPE or cell_2 == MEDIUM_CELL_TYPE:
-                                cell_to_update.setText(str('16.0'))
+                                if self.focal_plasticity_plugin_used:
+                                    cell_to_update.setText(str('-'))
+                                else:
+                                    cell_to_update.setText(str('16.0'))
                             else:
                                 cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))
                         else:  # Same cell type contact:
-                            if cell_1 == MEDIUM_CELL_TYPE and cell_2 == MEDIUM_CELL_TYPE:
+                            if (cell_1 == MEDIUM_CELL_TYPE and cell_2 == MEDIUM_CELL_TYPE) and \
+                                    self.focal_plasticity_plugin_used:
                                 cell_to_update.setText(str('-'))
                             else:
                                 cell_to_update.setText(str(DEFAULT_SORT_ENERGY))
@@ -402,7 +410,8 @@ class ContactPluginWidget(QWidget):
 
     def setUpCellMixingContactEnergiesMatrix(self):
         """ Generates default contact energies for contact matrix that should lead to cell type mixing.
-                    Updates the contact_matrix_table (QTableWidget) with new values. """
+                    Updates the contact_matrix_table (QTableWidget) with new values. If FocalPoint Plasticity
+            Plugin is used then all Medium entries are '-'. """
 
         table_cell_font = QFont()
         table_cell_font.setPointSize(CONTACT_TABLE_HEADER_FONT_SIZE)
@@ -415,11 +424,14 @@ class ContactPluginWidget(QWidget):
                         cell_2: str = self.ui.contact_matrix_table.verticalHeaderItem(column).text()
                         if row < column:
                             if cell_1 == MEDIUM_CELL_TYPE or cell_2 == MEDIUM_CELL_TYPE:
-                                cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))  # Do not mix with Medium cell type
+                                if self.focal_plasticity_plugin_used:
+                                    cell_to_update.setText(str('-'))
+                                else:
+                                    cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))  # Do not mix with Medium cell type
                             else:
                                 cell_to_update.setText(str(DEFAULT_MIX_ENERGY))
                         else:  # Same cell type contact:
-                            if cell_1 == MEDIUM_CELL_TYPE and cell_2 == MEDIUM_CELL_TYPE:
+                            if (cell_1 == MEDIUM_CELL_TYPE and cell_2 == MEDIUM_CELL_TYPE) and self.focal_plasticity_plugin_used:
                                 cell_to_update.setText(str('-'))
                             else:
                                 cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))

--- a/cc3d/twedit5/Plugins/CC3DProject/ContactPluginWidget.py
+++ b/cc3d/twedit5/Plugins/CC3DProject/ContactPluginWidget.py
@@ -56,7 +56,7 @@ class ContactPluginWidget(QWidget):
         self.contact_cell_cell_energy: list[tuple[str, str, str]] = []  # list[ tuple[ mol1, mol2, binding param]]
         self.internal_contact_cell_cell_energy: list[tuple[str, str, str]] = []  # list[ tuple[ mol1, mol2, binding param]]
         self.contact_internal_callBack = contact_internal_call_back
-        self.focal_plasticity_plugin_used = False
+        #self.focal_plasticity_plugin_used = False
 
         descr_font = QFont()
         descr_font.setPointSize(CONTACT_DESCR_FONT_SIZE)
@@ -159,16 +159,9 @@ class ContactPluginWidget(QWidget):
         for row in range(0, self.ui.contact_matrix_table.rowCount()):
             for column in range(0, self.ui.contact_matrix_table.columnCount()):
                 if row <= column:
-                    cell_type_h = self.ui.contact_matrix_table.horizontalHeaderItem(column).text()
-                    cell_type_v = self.ui.contact_matrix_table.verticalHeaderItem(row).text()
                     cell_to_update: QTableWidgetItem = self.ui.contact_matrix_table.item(row, column)
                     if cell_to_update:
-                        if (cell_type_h == MEDIUM_CELL_TYPE or cell_type_v == MEDIUM_CELL_TYPE) and self.focal_plasticity_plugin_used:
-                            # Check if both 'MEDIUM_CELL_TYPE' type, if so then default energy is '-'
-                            # when FocalPoint Plasticity Plugin is used.
-                            cell_to_update.setText("-")
-                        else:
-                            cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))
+                        cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))
                     else:  # create new table cell (QTableWidgetItem):
                         energy_par_item = QTableWidgetItem(str(DEFAULT_CONTACT_ENERGY))
                         energy_par_item.setFont(table_cell_font)
@@ -258,8 +251,7 @@ class ContactPluginWidget(QWidget):
         return issues
 
     def initContactMatrix(self, cell_types: list[str]):
-        """ Sets up the initial Contact matrix then fills with default values. If FocalPoint Plasticity
-            Plugin is used then all Medium entries are '-'. """
+        """ Sets up the initial Contact matrix then fills with default values. """
 
         header_font = QFont()
         header_font.setPointSize(CONTACT_TABLE_HEADER_FONT_SIZE)
@@ -286,12 +278,7 @@ class ContactPluginWidget(QWidget):
                 if cell_type_h == MEDIUM_CELL_TYPE:
                     medium_col = row
                 if row <= column:
-                    if (cell_type_h == MEDIUM_CELL_TYPE or medium_col == column) and \
-                            self.focal_plasticity_plugin_used:
-                        # Check if 'MEDIUM_CELL_TYPE' type and FPP used, if so then default energy is '-'.
-                        binding_par_item = QTableWidgetItem("-")
-                    else:
-                        binding_par_item = QTableWidgetItem(str(DEFAULT_CONTACT_ENERGY))
+                    binding_par_item = QTableWidgetItem(str(DEFAULT_CONTACT_ENERGY))
                     binding_par_item.setFont(header_font)
                     binding_par_item.setTextAlignment(Qt.AlignCenter)
 
@@ -373,8 +360,7 @@ class ContactPluginWidget(QWidget):
 
     def setUpSortedCellsContactEnergiesMatrix(self):
         """ Generates default contact energies for contact matrix that should lead to cell type sorting.
-            Updates the contact_matrix_table (QTableWidget) with new energy values. If FocalPoint Plasticity
-            Plugin is used then all 'Medium' entries are '-'. """
+            Updates the contact_matrix_table (QTableWidget) with new energy values. """
 
         table_cell_font = QFont()
         table_cell_font.setPointSize(CONTACT_TABLE_HEADER_FONT_SIZE)
@@ -387,18 +373,11 @@ class ContactPluginWidget(QWidget):
                         cell_2: str = self.ui.contact_matrix_table.verticalHeaderItem(column).text()
                         if row < column:
                             if cell_1 == MEDIUM_CELL_TYPE or cell_2 == MEDIUM_CELL_TYPE:
-                                if self.focal_plasticity_plugin_used:
-                                    cell_to_update.setText(str('-'))
-                                else:
-                                    cell_to_update.setText(str('16.0'))
+                                cell_to_update.setText(str('16.0'))
                             else:
                                 cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))
                         else:  # Same cell type contact:
-                            if (cell_1 == MEDIUM_CELL_TYPE and cell_2 == MEDIUM_CELL_TYPE) and \
-                                    self.focal_plasticity_plugin_used:
-                                cell_to_update.setText(str('-'))
-                            else:
-                                cell_to_update.setText(str(DEFAULT_SORT_ENERGY))
+                            cell_to_update.setText(str(DEFAULT_SORT_ENERGY))
                     else:  # create new table cell:
                         energy_par_item = QTableWidgetItem(str(DEFAULT_CONTACT_ENERGY))
                         energy_par_item.setFont(table_cell_font)
@@ -410,8 +389,7 @@ class ContactPluginWidget(QWidget):
 
     def setUpCellMixingContactEnergiesMatrix(self):
         """ Generates default contact energies for contact matrix that should lead to cell type mixing.
-                    Updates the contact_matrix_table (QTableWidget) with new values. If FocalPoint Plasticity
-            Plugin is used then all Medium entries are '-'. """
+                    Updates the contact_matrix_table (QTableWidget) with new values. """
 
         table_cell_font = QFont()
         table_cell_font.setPointSize(CONTACT_TABLE_HEADER_FONT_SIZE)
@@ -424,17 +402,11 @@ class ContactPluginWidget(QWidget):
                         cell_2: str = self.ui.contact_matrix_table.verticalHeaderItem(column).text()
                         if row < column:
                             if cell_1 == MEDIUM_CELL_TYPE or cell_2 == MEDIUM_CELL_TYPE:
-                                if self.focal_plasticity_plugin_used:
-                                    cell_to_update.setText(str('-'))
-                                else:
-                                    cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))  # Do not mix with Medium cell type
+                                cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))  # Do not mix with Medium cell type
                             else:
                                 cell_to_update.setText(str(DEFAULT_MIX_ENERGY))
                         else:  # Same cell type contact:
-                            if (cell_1 == MEDIUM_CELL_TYPE and cell_2 == MEDIUM_CELL_TYPE) and self.focal_plasticity_plugin_used:
-                                cell_to_update.setText(str('-'))
-                            else:
-                                cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))
+                            cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))
                     else:  # create new table cell if none there:
                         energy_par_item = QTableWidgetItem(str(DEFAULT_CONTACT_ENERGY))
                         energy_par_item.setFont(table_cell_font)

--- a/cc3d/twedit5/Plugins/CC3DProject/ContactPluginWidget.py
+++ b/cc3d/twedit5/Plugins/CC3DProject/ContactPluginWidget.py
@@ -157,9 +157,16 @@ class ContactPluginWidget(QWidget):
         for row in range(0, self.ui.contact_matrix_table.rowCount()):
             for column in range(0, self.ui.contact_matrix_table.columnCount()):
                 if row <= column:
+                    cell_type_h = self.ui.contact_matrix_table.horizontalHeaderItem(column).text()
+                    cell_type_v = self.ui.contact_matrix_table.verticalHeaderItem(row).text()
                     cell_to_update: QTableWidgetItem = self.ui.contact_matrix_table.item(row, column)
                     if cell_to_update:
-                        cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))
+                        if cell_type_h == MEDIUM_CELL_TYPE and cell_type_v == MEDIUM_CELL_TYPE:
+                            # Check if both 'MEDIUM_CELL_TYPE' type, if so then default energy is '-',
+                            # Contact between Medium cell types is nonsensical.
+                            cell_to_update.setText("-")
+                        else:
+                            cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))
                     else:  # create new table cell (QTableWidgetItem):
                         energy_par_item = QTableWidgetItem(str(DEFAULT_CONTACT_ENERGY))
                         energy_par_item.setFont(table_cell_font)
@@ -215,6 +222,9 @@ class ContactPluginWidget(QWidget):
         cell_1 = self.ui.contact_matrix_table.horizontalHeaderItem(item.column()).text()
         cell_2 = self.ui.contact_matrix_table.verticalHeaderItem(item.row()).text()
         val_str = item.text()
+        # can also be "-", need to check:
+        if val_str.strip() == "-":
+            return True
         if self.checkEnergyValue(val_str):
             return True
         else:
@@ -269,8 +279,16 @@ class ContactPluginWidget(QWidget):
         for row in range(0, cell_type_count):
             self.ui.contact_matrix_table.insertRow(row)
             for column in range(0, cell_type_count):
+                cell_type_h = self.ui.contact_matrix_table.horizontalHeaderItem(column).text()
+                if cell_type_h == MEDIUM_CELL_TYPE:
+                    medium_col = column
                 if row <= column:
-                    binding_par_item = QTableWidgetItem(str(DEFAULT_CONTACT_ENERGY))
+                    if cell_type_h == MEDIUM_CELL_TYPE and row == medium_col:
+                        # Check if 'MEDIUM_CELL_TYPE' type, if so then default energy is '-',
+                        # Adhesion energy between Medium cell types is nonsensical.
+                        binding_par_item = QTableWidgetItem("-")
+                    else:
+                        binding_par_item = QTableWidgetItem(str(DEFAULT_CONTACT_ENERGY))
                     binding_par_item.setFont(header_font)
                     binding_par_item.setTextAlignment(Qt.AlignCenter)
 
@@ -370,7 +388,7 @@ class ContactPluginWidget(QWidget):
                                 cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))
                         else:  # Same cell type contact:
                             if cell_1 == MEDIUM_CELL_TYPE and cell_2 == MEDIUM_CELL_TYPE:
-                                cell_to_update.setText(str('0.0'))
+                                cell_to_update.setText(str('-'))
                             else:
                                 cell_to_update.setText(str(DEFAULT_SORT_ENERGY))
                     else:  # create new table cell:
@@ -393,14 +411,18 @@ class ContactPluginWidget(QWidget):
                 if row <= column:
                     cell_to_update: QTableWidgetItem = self.ui.contact_matrix_table.item(row, column)
                     if cell_to_update:
+                        cell_1: str = self.ui.contact_matrix_table.horizontalHeaderItem(row).text()
+                        cell_2: str = self.ui.contact_matrix_table.verticalHeaderItem(column).text()
                         if row < column:
-                            if self.ui.contact_matrix_table.horizontalHeaderItem(row).text() == MEDIUM_CELL_TYPE or \
-                                    self.ui.contact_matrix_table.verticalHeaderItem(column).text() == MEDIUM_CELL_TYPE:
+                            if cell_1 == MEDIUM_CELL_TYPE or cell_2 == MEDIUM_CELL_TYPE:
                                 cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))  # Do not mix with Medium cell type
                             else:
                                 cell_to_update.setText(str(DEFAULT_MIX_ENERGY))
                         else:  # Same cell type contact:
-                            cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))
+                            if cell_1 == MEDIUM_CELL_TYPE and cell_2 == MEDIUM_CELL_TYPE:
+                                cell_to_update.setText(str('-'))
+                            else:
+                                cell_to_update.setText(str(DEFAULT_CONTACT_ENERGY))
                     else:  # create new table cell if none there:
                         energy_par_item = QTableWidgetItem(str(DEFAULT_CONTACT_ENERGY))
                         energy_par_item.setFont(table_cell_font)

--- a/cc3d/twedit5/Plugins/CC3DProject/ContactPluginWidget.py
+++ b/cc3d/twedit5/Plugins/CC3DProject/ContactPluginWidget.py
@@ -12,7 +12,7 @@ CONTACT_SMALL_FONT_SIZE = 8
 DEFAULT_CONTACT_ENERGY = '10.0'
 DEFAULT_MIX_ENERGY = '2.0'
 DEFAULT_SORT_ENERGY = '2.0'
-DEFAULT_CONTACT_NEIGHBOR_ORDER = 2
+DEFAULT_CONTACT_NEIGHBOR_ORDER = 4
 MEDIUM_CELL_TYPE = "Medium"
 NEIGHBOR_ORDER_TOOLTIP_1 = "How many nearby pixels the Contact(Internal) plugin algorithm will check " \
                            "each time it needs to do an energy calculation."

--- a/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
+++ b/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
@@ -2202,6 +2202,7 @@ class NewSimulationWizard(QWizard, ui_newsimulationwizard.Ui_NewSimulationWizard
     def setUpContactPluginPage(self):
         contact_page: QWizardPage = self.get_page_by_name(CONTACT_PAGE_NAME)
         cell_types: list[str] = []
+        self.contact_form.focal_plasticity_plugin_used = self.fppCHB.isChecked()
         for row in range(self.cellTypeTable.rowCount()):
             cell_type = str(self.cellTypeTable.item(row, 0).text())
             cell_types.append(cell_type)

--- a/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
+++ b/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
@@ -2206,9 +2206,24 @@ class NewSimulationWizard(QWizard, ui_newsimulationwizard.Ui_NewSimulationWizard
         for row in range(self.cellTypeTable.rowCount()):
             cell_type = str(self.cellTypeTable.item(row, 0).text())
             cell_types.append(cell_type)
-        self.contact_form.initContactMatrix(cell_types)
-        if self.internalContactCB.isChecked():
-            self.contact_form.initInternalContactMatrix(cell_types)
+
+        # check if existing contact plugin info already there (and same cell types):
+        if len(self.contact_form.cell_types) == len(cell_types):
+            cell_found = False
+            for cell in cell_types:
+                if cell in self.contact_form.cell_types:
+                    cell_found = True
+                else:
+                    cell_found = False
+                    break
+            if not cell_found:
+                self.contact_form.initContactMatrix(cell_types)
+                if self.internalContactCB.isChecked():
+                    self.contact_form.initInternalContactMatrix(cell_types)
+        else:
+            self.contact_form.initContactMatrix(cell_types)
+            if self.internalContactCB.isChecked():
+                self.contact_form.initInternalContactMatrix(cell_types)
 
 
 

--- a/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
+++ b/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
@@ -1072,7 +1072,7 @@ class NewSimulationWizard(QWizard, ui_newsimulationwizard.Ui_NewSimulationWizard
         if len(self.rxn_diffusionFE_add_data) > 1:  # Load existing user data, if exists
             popup.set_data(self.rxn_diffusionFE_add_data[field_name])
         if popup.exec_() == QDialog.Accepted:
-            extra_settings: dict[str:str] = popup.get_data()
+            extra_settings: dict[str, str] = popup.get_data()
 
             #for key in extra_settings:
                 # print(f"{key}: {extra_settings[key]}")
@@ -2202,7 +2202,6 @@ class NewSimulationWizard(QWizard, ui_newsimulationwizard.Ui_NewSimulationWizard
     def setUpContactPluginPage(self):
         contact_page: QWizardPage = self.get_page_by_name(CONTACT_PAGE_NAME)
         cell_types: list[str] = []
-        self.contact_form.focal_plasticity_plugin_used = self.fppCHB.isChecked()
         for row in range(self.cellTypeTable.rowCount()):
             cell_type = str(self.cellTypeTable.item(row, 0).text())
             cell_types.append(cell_type)


### PR DESCRIPTION
Updates based on comments from Wizard issues #71.
Contact/Internal plugin Wizard page of Twedit:
1. Set default neighborhood order to '4' for contact plugin.
2-3. Contact/Internal plugin Wizard no longer autogenerates contact energies for Medium-Medium pairs. Wizard fills entry as '-' which is ignored when xml generated. User can still override values if they want to.